### PR TITLE
Amends Django version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django>=1.6.0
+Django==1.6.5
 django-bootstrap3==4.11.0
 requests>=2.2.1
 wsgiref==0.1.2


### PR DESCRIPTION
For new version of Django(eg. 1.11.24), 'patterns' was removed from django.conf.urls. 
So it would be helpful to specify the precise version of Django to avoid unhandled exceptions.  